### PR TITLE
Add Heart Rate Analysis to sidebar

### DIFF
--- a/apps/oura-dashboard/src/components/sidebar.py
+++ b/apps/oura-dashboard/src/components/sidebar.py
@@ -46,6 +46,7 @@ def render_sidebar(queries):
         "Overview",
         "Sleep Analysis",
         "Activity Tracking",
+        "Heart Rate Analysis",
         "Readiness & Recovery",
         "Trends & Insights",
         "Detailed Reports"


### PR DESCRIPTION
## Summary
- insert **Heart Rate Analysis** option in sidebar navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0da3bba8833383816eb0365e33fd