### PR TITLE
Fix dashboard init script import

### DIFF
--- a/apps/oura-dashboard/scripts/init_database.py
+++ b/apps/oura-dashboard/scripts/init_database.py
@@ -9,7 +9,6 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 
 from sqlalchemy import create_engine, inspect
-from src.dashboard.database_models import Base
 from src.dashboard.config import get_database_connection_string
 from externalconnections.fetch_oura_secrets import get_postgres_credentials, build_postgres_connection_string
 


### PR DESCRIPTION
## Summary
- remove nonexistent Base import from dashboard init script

## Testing
- `python -m py_compile apps/oura-dashboard/scripts/init_database.py`

------
https://chatgpt.com/codex/tasks/task_e_685e0e44c31c8333a36359c450d00d95