### PR TITLE
Add login support to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+## Oura Dashboard Authentication
+
+The dashboard under `apps/oura-dashboard` now supports optional username and
+password authentication using [`streamlit-authenticator`](https://github.com/mkhorasani/streamlit-authenticator).
+
+Set the following environment variables to enable authentication:
+
+* `REQUIRE_AUTH` – set to `true` to require login.
+* `DASHBOARD_USERNAME` – login username (default `admin`).
+* `DASHBOARD_PASSWORD` – plain text password used to generate a hash on start.
+* `DASHBOARD_NAME` – full name shown in the UI (optional).
+* `DASHBOARD_EMAIL` – email address displayed in account info (optional).
+* `AUTH_COOKIE_KEY` – secret key for the login cookie.
+
+If `REQUIRE_AUTH` is not set or is `false`, the dashboard behaves as before and
+does not ask for credentials.

--- a/apps/oura-dashboard/requirements.txt
+++ b/apps/oura-dashboard/requirements.txt
@@ -3,6 +3,7 @@
 # Web framework
 streamlit>=1.28.0,<2.0.0
 streamlit-extras>=0.3.5
+streamlit-authenticator>=0.2.2
 
 # Database
 sqlalchemy>=2.0.0,<3.0.0

--- a/apps/oura-dashboard/src/dashboard/app.py
+++ b/apps/oura-dashboard/src/dashboard/app.py
@@ -3,9 +3,12 @@ Oura Health Dashboard - Main Application Entry Point
 """
 import streamlit as st
 from datetime import datetime
+import os
+
+import streamlit_authenticator as stauth
 
 # Import configuration
-from config import get_database_connection_string
+from config import get_database_connection_string, REQUIRE_AUTH
 
 # Import queries
 from queries import OuraDataQueries
@@ -34,6 +37,34 @@ st.set_page_config(
 
 # Apply custom CSS
 apply_custom_styles()
+
+# Authentication
+if REQUIRE_AUTH:
+    creds = {
+        "usernames": {
+            os.environ.get("DASHBOARD_USERNAME", "admin"): {
+                "email": os.environ.get("DASHBOARD_EMAIL", "admin@example.com"),
+                "name": os.environ.get("DASHBOARD_NAME", "Admin"),
+                "password": stauth.Hasher([
+                    os.environ.get("DASHBOARD_PASSWORD", "changeme")
+                ]).generate()[0],
+            }
+        }
+    }
+    authenticator = stauth.Authenticate(
+        creds,
+        cookie_name="oura_dashboard",
+        key=os.environ.get("AUTH_COOKIE_KEY", "auth_key"),
+        cookie_expiry_days=1,
+    )
+    name, auth_status, username = authenticator.login("Login", "main")
+    if auth_status is False:
+        st.error("Username or password is incorrect")
+        st.stop()
+    elif auth_status is None:
+        st.warning("Please enter your username and password")
+        st.stop()
+    authenticator.logout("Logout", "sidebar")
 
 # Initialize session state
 if 'queries' not in st.session_state:


### PR DESCRIPTION
## Summary
- secure the Streamlit dashboard with optional username/password login
- document environment variables for authentication
- add streamlit-authenticator to dashboard requirements

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e66fd49bc8333af02600694ea2974