### PR TITLE
Add auth-service requirements

### DIFF
--- a/apps/auth-service/requirements.txt
+++ b/apps/auth-service/requirements.txt
@@ -1,0 +1,8 @@
+fastapi>=0.110.0
+uvicorn>=0.27.0
+sqlalchemy>=2.0.0
+pydantic>=2.0.0
+cachetools>=5.3.0
+psycopg2-binary>=2.9.7
+boto3>=1.28.0
+slowapi>=0.1.8


### PR DESCRIPTION
## Summary
- populate `apps/auth-service/requirements.txt` with required packages

## Testing
- `docker build apps/auth-service -t auth-service-test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9335358083339536351382404b28