### PR TITLE
Add admin seeding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,21 @@ Set the following environment variables to enable authentication:
 
 If `REQUIRE_AUTH` is not set or is `false`, the dashboard behaves as before and
 does not ask for credentials.
+
+## Auth Service Setup
+
+Run the provided scripts to create the database schema and an initial admin user.
+
+1. Initialize the database tables:
+
+   ```bash
+   python apps/auth-service/src/scripts/init_database.py --create-db
+   ```
+
+2. Seed an admin user (replace the email and password as needed):
+
+   ```bash
+   python apps/auth-service/src/scripts/seed_users.py --email admin@example.com --password mypassword
+   ```
+
+The seeding script retrieves database credentials from AWS Secrets Manager by default. A connection string can be supplied with `--connection-string` to override this behaviour.

--- a/apps/auth-service/src/scripts/seed_users.py
+++ b/apps/auth-service/src/scripts/seed_users.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Seed Auth Service database with an initial admin user."""
+import sys
+import os
+import argparse
+import logging
+
+# Allow imports from auth service modules
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from auth.database_models import AuthorizedUser
+from externalconnections.fetch_secrets import get_postgres_credentials, build_postgres_connection_string
+from auth import config
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def add_admin_user(connection_string: str, email: str, password: str) -> None:
+    """Insert an admin user if one does not already exist."""
+    engine = create_engine(connection_string)
+    SessionLocal = sessionmaker(bind=engine)
+
+    session = SessionLocal()
+    try:
+        existing = session.query(AuthorizedUser).filter(AuthorizedUser.email == email.lower()).first()
+        if existing:
+            logger.info("User %s already exists", email)
+            return
+
+        user = AuthorizedUser(
+            email=email.lower(),
+            full_name="Admin",
+            is_admin=True,
+            created_by=email.lower(),
+            notes="Seeded admin user"
+        )
+        session.add(user)
+        session.commit()
+        logger.info("Created admin user %s", email)
+    except Exception as exc:
+        session.rollback()
+        logger.error("Failed to create admin user: %s", exc)
+        raise
+    finally:
+        session.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed the database with an initial admin user")
+    parser.add_argument("--email", required=True, help="Admin email address")
+    parser.add_argument("--password", required=True, help="Admin password")
+    parser.add_argument("--connection-string", help="PostgreSQL connection string (overrides AWS secrets)")
+    args = parser.parse_args()
+
+    if args.connection_string:
+        connection_string = args.connection_string
+    else:
+        postgres_secrets = get_postgres_credentials(
+            secret_name=config.POSTGRES_SECRETS_NAME,
+            region_name=config.AWS_REGION,
+        )
+        connection_string = build_postgres_connection_string(postgres_secrets)
+
+    add_admin_user(connection_string, args.email, args.password)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new seed_users.py script to create an initial admin user
- document how to initialize and seed the Auth Service database

## Testing
- `python -m py_compile apps/auth-service/src/scripts/seed_users.py`
- `python -m py_compile apps/auth-service/src/scripts/init_database.py apps/auth-service/src/scripts/seed_users.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e93405be0833393ee5d3791c5b514