### PR TITLE
Sync API keys from secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,23 @@ Run the provided scripts to create the database schema and an initial admin user
    ```
 
 The seeding script retrieves database credentials from AWS Secrets Manager by default. A connection string can be supplied with `--connection-string` to override this behaviour.
+
+### API Key Secret Format
+
+The auth service can seed initial API keys from the secret referenced by `AUTH_API_SECRETS_NAME` (default `auth-service/api-keys`).
+The secret should be a JSON object structured as follows:
+
+```json
+{
+  "master_api_key": "your-master-key",
+  "admin_api_keys": {
+    "some-admin-key": {
+      "name": "Main Admin Key",
+      "email": "admin@example.com",
+      "is_admin": true
+    }
+  }
+}
+```
+
+On startup the service will insert or update these keys in the database.


### PR DESCRIPTION
## Summary
- load API key config during startup
- store API keys in the database if missing
- document the secret format for API keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eaeff02dc83338d4ad810d8053c3d