### PR TITLE
Define DB credentials in auth-service config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ Run the provided scripts to create the database schema and an initial admin user
    ```
 
 The seeding script retrieves database credentials from AWS Secrets Manager by default. A connection string can be supplied with `--connection-string` to override this behaviour.
+
+Alternatively, you can provide the database connection details using environment variables:
+
+* `DATABASE_HOST` – database hostname
+* `DATABASE_PORT` – database port (default `5432`)
+* `DATABASE_NAME` – database name (default `auth_service`)
+* `DATABASE_USER` – database username
+* `DATABASE_PASSWORD` – database user password

--- a/apps/auth-service/src/auth/config.py
+++ b/apps/auth-service/src/auth/config.py
@@ -10,6 +10,8 @@ API_SECRETS_NAME = os.environ.get('AUTH_API_SECRETS_NAME', 'auth-service/api-key
 DATABASE_HOST = os.environ.get('DATABASE_HOST', None)
 DATABASE_PORT = os.environ.get('DATABASE_PORT', '5432')
 DATABASE_NAME = os.environ.get('DATABASE_NAME', 'auth_service')
+DATABASE_USER = os.environ.get('DATABASE_USER', None)
+DATABASE_PASSWORD = os.environ.get('DATABASE_PASSWORD', None)
 
 # API Configuration
 API_HOST = os.environ.get('API_HOST', '0.0.0.0')


### PR DESCRIPTION
## Summary
- expose `DATABASE_USER` and `DATABASE_PASSWORD` in auth-service configuration
- document database environment variables in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eaed5651c8333a6723df9142102c3