### PR TITLE
Add database creds config to auth service

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,14 @@ The secret should be a JSON object structured as follows:
 ```
 
 On startup the service will insert or update these keys in the database.
+
+### Environment Variables
+
+When not using AWS Secrets Manager, the auth service can read database
+credentials from the following environment variables:
+
+* `DATABASE_HOST` – database host name.
+* `DATABASE_PORT` – database port (default `5432`).
+* `DATABASE_NAME` – database name (default `auth_service`).
+* `DATABASE_USER` – database username.
+* `DATABASE_PASSWORD` – database password.

--- a/apps/auth-service/src/auth/config.py
+++ b/apps/auth-service/src/auth/config.py
@@ -10,6 +10,8 @@ API_SECRETS_NAME = os.environ.get('AUTH_API_SECRETS_NAME', 'auth-service/api-key
 DATABASE_HOST = os.environ.get('DATABASE_HOST', None)
 DATABASE_PORT = os.environ.get('DATABASE_PORT', '5432')
 DATABASE_NAME = os.environ.get('DATABASE_NAME', 'auth_service')
+DATABASE_USER = os.environ.get('DATABASE_USER', None)
+DATABASE_PASSWORD = os.environ.get('DATABASE_PASSWORD', None)
 
 # API Configuration
 API_HOST = os.environ.get('API_HOST', '0.0.0.0')


### PR DESCRIPTION
## Summary
- define `DATABASE_USER` and `DATABASE_PASSWORD` in auth service configuration
- document auth service database environment variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ebf52254483339a75f1976c031907