### PR TITLE
Update auth-service dependencies & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ The secret should be a JSON object structured as follows:
 ```
 
 On startup the service will insert or update these keys in the database.
+
+### Building the Auth Service Docker image
+
+The Dockerfile for the authentication service lives in `apps/auth-service` and
+installs all Python dependencies from `requirements.txt`. Rebuild the image from
+the repository root whenever the dependency list changes:
+
+```bash
+docker build -t auth-service ./apps/auth-service
+```

--- a/apps/auth-service/Dockerfile
+++ b/apps/auth-service/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && \
 # Install Python dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt && \
-    pip install --no-cache-dir streamlit requests && \
     pip cache purge
 
 # Copy application code - paths relative to build context (./apps/auth-service)

--- a/apps/auth-service/requirements.txt
+++ b/apps/auth-service/requirements.txt
@@ -6,3 +6,5 @@ cachetools>=5.3.0
 psycopg2-binary>=2.9.7
 boto3>=1.28.0
 slowapi>=0.1.8
+streamlit>=1.28.0
+requests>=2.31.0


### PR DESCRIPTION
## Summary
- include streamlit and requests in auth-service requirements
- remove extra pip installs in auth-service Dockerfile
- add section on building auth-service image to README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ebf5525c0833385a0b93333b7d2c4