### PR TITLE
Fix FastAPI dependency type errors

### DIFF
--- a/apps/auth-service/requirements.txt
+++ b/apps/auth-service/requirements.txt
@@ -2,6 +2,7 @@ fastapi>=0.110.0
 uvicorn>=0.27.0
 sqlalchemy>=2.0.0
 pydantic>=2.0.0
+email-validator>=2.0.0
 cachetools>=5.3.0
 psycopg2-binary>=2.9.7
 boto3>=1.28.0

--- a/apps/auth-service/src/auth/admin_api.py
+++ b/apps/auth-service/src/auth/admin_api.py
@@ -79,7 +79,7 @@ class ApplicationResponse(BaseModel):
 # Admin authentication dependency
 async def verify_admin(
     x_api_key: str = Header(None, alias=config.API_KEY_HEADER),
-    req: Request | None = None,
+    req: Request = None,
     db: Session = Depends(get_db_session)
 ):
     """Verify that the request is from an admin user"""

--- a/apps/auth-service/src/auth/api.py
+++ b/apps/auth-service/src/auth/api.py
@@ -53,7 +53,7 @@ class HealthResponse(BaseModel):
 # Dependency for API key authentication
 async def verify_api_key(
     x_api_key: str = Header(None, alias=config.API_KEY_HEADER),
-    req: Request | None = None,
+    req: Request = None,
 ):
     """Verify API key for protected endpoints."""
     if not config.ENABLE_API_KEY_AUTH:


### PR DESCRIPTION
## Summary
- include `email-validator` dependency for auth-service
- fix optional `Request` annotations that broke FastAPI model generation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f4182e0dc8333a61c6b05b7fc2a3b